### PR TITLE
Replaced the Mapzen geocoder with Mapbox

### DIFF
--- a/graphs/branches/HER Place.json
+++ b/graphs/branches/HER Place.json
@@ -499,7 +499,7 @@
                         ], 
                         "overlayOpacity": 0, 
                         "featurePointSize": "5", 
-                        "geocodeProvider": "MapzenGeocoder", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
                         "zoom": 11.068933439076746, 
                         "label": "", 
                         "featureLineWidth": 1, 

--- a/graphs/resource_models/DISCO Project.json
+++ b/graphs/resource_models/DISCO Project.json
@@ -2061,7 +2061,7 @@
                         ], 
                         "overlayOpacity": 0, 
                         "featurePointSize": "5", 
-                        "geocodeProvider": "MapzenGeocoder", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
                         "zoom": 11.068933439076746, 
                         "label": "", 
                         "featureLineWidth": 1, 

--- a/graphs/resource_models/HER Activities.json
+++ b/graphs/resource_models/HER Activities.json
@@ -318,7 +318,7 @@
                         "pitch": 0, 
                         "overlayOpacity": 0, 
                         "geocoderVisible": true, 
-                        "geocodeProvider": "MapzenGeocoder", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
                         "zoom": 10, 
                         "featureLineWidth": 1, 
                         "geocodePlaceholder": "Search", 

--- a/graphs/resource_models/HER Actors.json
+++ b/graphs/resource_models/HER Actors.json
@@ -2369,7 +2369,7 @@
                         ], 
                         "overlayOpacity": 0, 
                         "featurePointSize": 3, 
-                        "geocodeProvider": "MapzenGeocoder", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
                         "zoom": 0, 
                         "label": "Spatial Coordinates Geometry", 
                         "featureLineWidth": 1, 

--- a/graphs/resource_models/HER Find Model.json
+++ b/graphs/resource_models/HER Find Model.json
@@ -418,7 +418,7 @@
                         "pitch": 0, 
                         "overlayOpacity": 0, 
                         "geocoderVisible": true, 
-                        "geocodeProvider": "MapzenGeocoder", 
+                        "geocodeProvider": "10000000-0000-0000-0000-010000000000", 
                         "zoom": 10, 
                         "featureLineWidth": 1, 
                         "geocodePlaceholder": "Search", 


### PR DESCRIPTION
Geocoders are now identified by their geocoder id in the database rather than the proxy class name. 